### PR TITLE
Adding jupyter notebook for computation of clinical parameters of the tum cohort

### DIFF
--- a/correlations_with_clinical_scores/Statistics_Cohort_TUM.ipynb
+++ b/correlations_with_clinical_scores/Statistics_Cohort_TUM.ipynb
@@ -1,0 +1,534 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9f742ba2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a42aaedd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_seg_ids_reduced = pd.read_csv(\"segmentation_cohort_ids_final.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "82667f5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_patients = pd.read_csv(\"data.patients.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f54f15ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_patients = df_patients[[\"pat.id\", \"mr.id\", \"birth\", \"sex\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d4901d95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_patients = df_patients.rename(columns={\n",
+    "    \"pat.id\": \"sap_id\",\n",
+    "    \"mr.id\": \"subject\",\n",
+    "    \"ms\": \"ms_type\",\n",
+    "    \"diag.first\": \"diagnosis_date\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "37bb5ac5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_patients[\"subject\"] = df_patients[\"subject\"].apply(lambda x: f\"sub-m{x:06d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f2f79c59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged_df = pd.merge(df_seg_ids_reduced,df_patients, on=\"subject\", how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "263ad54c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged_df[\"session\"]= pd.to_datetime(merged_df[\"session\"].str[4:], format=\"%Y%m%d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "08d32789",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged_df[\"birth\"]= pd.to_datetime(merged_df[\"birth\"],format=\"%Y-%m-%d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "43c134a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged_df[\"age_at_session\"] = (merged_df[\"session\"]-merged_df[\"birth\"]).apply(lambda x: int(np.rint(x.days / 365)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "9377a0b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_edss_spine = pd.read_csv(\"edss_spine.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "54ff32db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_edss_spine = df_edss_spine[[\"mr.id\", \"spine.date\", \"edss.score.closest\", \"diagnosis\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "498934fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_edss_spine = df_edss_spine.rename(columns={\n",
+    "    \"pat.id\": \"sap_id\",\n",
+    "    \"mr.id\": \"subject\",\n",
+    "    \"spine.date\": \"session\",\n",
+    "    \"edss.score.closest\": \"closest_edss\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "8c5bfd43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_edss_spine[\"subject\"] = df_edss_spine[\"subject\"].apply(lambda x: f\"sub-m{x:06d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2f5039fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_edss_spine[\"session\"]= pd.to_datetime(df_edss_spine[\"session\"], format=\"%m/%d/%Y\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "38cfa465",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_stats = pd.merge(merged_df, df_edss_spine, on=[\"subject\", \"session\"], how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "99fb4cc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_stats = df_stats.sort_values(by=[\"subject\", \"session\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "d8fa601f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_baseline = df_stats.groupby(\"subject\").nth(0).reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "6c0ea765",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_followup = df_stats.groupby(\"subject\").nth(1).reset_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c049dfce",
+   "metadata": {},
+   "source": [
+    "#### General Statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "42361715",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unique_cnts_diagnosis_baseline=df_baseline[\"diagnosis\"].value_counts()\n",
+    "unique_cnts_sex_baseline=df_baseline[\"sex\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "aab6d993",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RRMS    277\n",
+       "SPMS     14\n",
+       "CIS      11\n",
+       "PPMS     11\n",
+       "NNO       2\n",
+       "NMO       1\n",
+       "RIS       1\n",
+       "Name: diagnosis, dtype: int64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unique_cnts_diagnosis_baseline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ab00ce25",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "F    209\n",
+       "M    108\n",
+       "Name: sex, dtype: int64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "unique_cnts_sex_baseline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4c9a6df",
+   "metadata": {},
+   "source": [
+    "#### Baseline vs Followup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "02b433b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EDSS Baseline mean: 1.8028846153846154,std: 1.4463919005760304\n"
+     ]
+    }
+   ],
+   "source": [
+    "baseline_edds_avg, baseline_edss_std =df_baseline[\"closest_edss\"].mean(), df_baseline[\"closest_edss\"].std()\n",
+    "print(f\"EDSS Baseline mean: {baseline_edds_avg},std: {baseline_edss_std}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "c8799a28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "followup_edds_avg, followup_edss_std =df_followup[\"closest_edss\"].mean(), df_followup[\"closest_edss\"].std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "3bbe6e94",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EDSS Follow-up mean: 2.022875816993464,std: 1.761463502254282\n"
+     ]
+    }
+   ],
+   "source": [
+    "followup_edds_avg, followup_edss_std\n",
+    "print(f\"EDSS Follow-up mean: {followup_edds_avg},std: {followup_edss_std}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "661dbb0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_stats = df_stats.sort_values(by=[\"subject\", \"session\"])\n",
+    "df_stats[\"session_diff\"] = df_stats.groupby(\"subject\")[\"session\"].diff()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "e7d0ab14",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean Time interval between bs vs fu [days]: 1142 days 09:59:37.287066240, std: 945 days 22:46:56.966734896\n"
+     ]
+    }
+   ],
+   "source": [
+    "session_diffs = df_stats[\"session_diff\"].dropna()\n",
+    "session_diff_mean, session_diff_std = session_diffs.mean(), session_diffs.std()\n",
+    "print(f\"Mean Time interval between bs vs fu [days]: {session_diff_mean}, std: {session_diff_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "96a0a50f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean Time interval between bs vs fu [years]: 3.127765650336725, std: 2.5898679546839714\n"
+     ]
+    }
+   ],
+   "source": [
+    "session_diffs_in_years = session_diffs.dt.days / 365.25\n",
+    "session_diff_y_mean, session_diff_y_std = session_diffs_in_years.mean(), session_diffs_in_years.std()\n",
+    "print(f\"Mean Time interval between bs vs fu [years]: {session_diff_y_mean}, std: {session_diff_y_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "b866ade3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Age at baseline, mean: 36.11671924290221, std: 10.44525835553932\n"
+     ]
+    }
+   ],
+   "source": [
+    "baseline_age_avg, baseline_age_std =df_baseline[\"age_at_session\"].mean(), df_baseline[\"age_at_session\"].std()\n",
+    "print(f\"Age at baseline, mean: {baseline_age_avg}, std: {baseline_age_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "a4f5a6fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Age at followup, mean: 39.27444794952682, std: 10.977699349191425\n"
+     ]
+    }
+   ],
+   "source": [
+    "followup_age_avg, followup_age_std =df_followup[\"age_at_session\"].mean(), df_followup[\"age_at_session\"].std()\n",
+    "print(f\"Age at followup, mean: {followup_age_avg}, std: {followup_age_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "d33f7b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_lesions = pd.read_csv(\"20241025_Brain_Spine_Cohort.csv\")\n",
+    "df_lesions = df_lesions[[\"subject_id\", \"baseline_spine_number_of_lesions\", \"baseline_spine_total_lesion_volume_mm3\",\n",
+    "                        \"followup_spine_number_of_lesions\", \"followup_spine_total_lesion_volume_mm3\"]]\n",
+    "df_lesions = df_lesions.rename(columns={\n",
+    "    \"subject_id\": \"subject\",\n",
+    "})\n",
+    "df_lesions[\"subject\"] = df_lesions[\"subject\"].apply(lambda x: f\"sub-m{x:06d}\")\n",
+    "df_lesions_merged = pd.merge(df_lesions, df_seg_ids_reduced, on=\"subject\", how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "701fb6e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lesion No. at baseline, mean: 3.0855365474339034, std: 3.333090837727155\n"
+     ]
+    }
+   ],
+   "source": [
+    "baseline_lesion_no_avg, baseline_lesion_no_std =df_lesions_merged[\"baseline_spine_number_of_lesions\"].mean(), df_lesions_merged[\"baseline_spine_number_of_lesions\"].std()\n",
+    "print(f\"Lesion No. at baseline, mean: {baseline_lesion_no_avg}, std: {baseline_lesion_no_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "25fa26fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lesion No. at follow-up, mean: 3.2052877138413685, std: 3.3504781873276643\n"
+     ]
+    }
+   ],
+   "source": [
+    "followup_lesion_no_avg, followup_lesion_no_std =df_lesions_merged[\"followup_spine_number_of_lesions\"].mean(), df_lesions_merged[\"followup_spine_number_of_lesions\"].std()\n",
+    "print(f\"Lesion No. at follow-up, mean: {followup_lesion_no_avg}, std: {followup_lesion_no_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "05b4e905",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lesion volume at baseline, mean: 369.5016098407464, std: 554.7801054583888\n"
+     ]
+    }
+   ],
+   "source": [
+    "baseline_lesion_vol_avg, baseline_lesion_vol_std =df_lesions_merged[\"baseline_spine_total_lesion_volume_mm3\"].mean(), df_lesions_merged[\"baseline_spine_total_lesion_volume_mm3\"].std()\n",
+    "print(f\"Lesion volume at baseline, mean: {baseline_lesion_vol_avg}, std: {baseline_lesion_vol_std}\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "bf6ab3a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lesion volume at baseline, mean: 398.29898996550855, std: 554.6139022152408\n"
+     ]
+    }
+   ],
+   "source": [
+    "followup_lesion_vol_avg, followup_lesion_vol_std =df_lesions_merged[\"followup_spine_total_lesion_volume_mm3\"].mean(), df_lesions_merged[\"followup_spine_total_lesion_volume_mm3\"].std()\n",
+    "print(f\"Lesion volume at baseline, mean: {followup_lesion_vol_avg}, std: {followup_lesion_vol_std}\") "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Adding statistics generation notebook for clinical parameters of the TUM dataset
This PR adds a Jupyter notebook used to merge the clinical statistics in various files of the tum cohort for this study. It includes several parameters, such as:

- Diagnosis of each patient
- EDSS scores at baseline and follow-up
- Patient age at baseline and follow-up
- Lesion load and number
- Since clinical parameters are sensitive data points, we cannot provide the cohort's CSV files.